### PR TITLE
Triggering lvimrc load on BufEnter

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -102,7 +102,7 @@ if has("autocmd")
     autocmd!
 
     " call s:LocalVimRC() when creating ore reading any file
-    autocmd VimEnter,BufNewFile,BufRead * call s:LocalVimRC()
+    autocmd BufEnter * call s:LocalVimRC()
   augroup END
 endif
 


### PR DESCRIPTION
Currently, the localvimrc loads the lvimrc files on `VimEnter`, `BufNewFile`
and `BufRead`. That should be enough for loading and switching files inside the
same window, but when working across windows this won't work for loading a
buffer which is already displayed on another window.

This commit switches the behavior to load on `BufEnter`, which should be less
efficient but work across windows.
