### PR TITLE
Change the default for localvimrc_persistence_file

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -97,7 +97,7 @@ endif
 " define default "localvimrc_persistence_file" {{{2
 " file where to store persistence information
 if (!exists("g:localvimrc_persistence_file"))
-  let s:localvimrc_persistence_file = expand('$HOME') . "/localvimrc_persistent"
+  let s:localvimrc_persistence_file = expand('$HOME') . "/.localvimrc_persistent"
 else
   let s:localvimrc_persistence_file = g:localvimrc_persistence_file
 endif


### PR DESCRIPTION
Use a hidden file by default.

This might not work as expected on Windows?! Should it use `_` instead
of `.` as with the default for `~/_vimrc`?

Ref: https://github.com/embear/vim-localvimrc/issues/19
