### PR TITLE
Add note about makeprg and sandbox

### DIFF
--- a/doc/localvimrc.txt
+++ b/doc/localvimrc.txt
@@ -46,6 +46,8 @@ a local vimrc in the root directory of a project modify the behavior of
 |:make| to change into a build directory and call make there:
 
   let &l:makeprg="cd ".g:localvimrc_script_dir."/build && make"
+  
+NOTE: This is only possible if you disable sandbox mode.
 
 ------------------------------------------------------------------------------
 *g:localvimrc_file*


### PR DESCRIPTION
Changing `makeprg` is not possible in sandbox mode. I added a corresponding notice to the help text.

From VIM's help on `makeprg`:

> This option cannot be set from a |modeline| or in the |sandbox|, for
> security reasons.

I don't know if this was introduced in a specific VIM version, so here is the version I'm using:

> VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Aug 12 2013 00:23:30)
