### PR TITLE
Do not writefile + rename, which messes up perms with "sudo vim"

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -584,14 +584,8 @@ function! s:LocalVimRCWritePersistent()
 
           call s:LocalVimRCDebug(3, "write persistent data: " . string(l:serialized))
 
-          " first write temporary file to avoid lost persistence information
-          " on write errors if partition is full
-          let l:tempname = s:localvimrc_persistence_file . "_TEMP"
-          if (writefile(l:serialized, l:tempname) == 0)
-            " writing succeeded so move file to final destination
-            call rename(l:tempname, s:localvimrc_persistence_file)
-          else
-            call s:LocalVimRCError("error while writing persistence file")
+          if (writefile(l:serialized, s:localvimrc_persistence_file) != 0)
+            call s:LocalVimRCError("error while writing persistence file!")
           endif
         else
           call s:LocalVimRCDebug(1, "unable to write persistence file '" . s:localvimrc_persistence_file . "'")


### PR DESCRIPTION
After `sudo vim` the persistence file is owned by root.

Ref: https://github.com/embear/vim-localvimrc/issues/28