### PR TITLE
Do not use `silent` with `source`

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -367,7 +367,7 @@ function! s:LocalVimRC()
         call s:LocalVimRCDebug(3, "g:localvimrc_sourced_once = " . g:localvimrc_sourced_once . ", g:localvimrc_sourced_once_for_file = " . g:localvimrc_sourced_once_for_file)
 
         " generate command
-        let l:command = "silent source " . fnameescape(l:rcfile)
+        let l:command = "source " . fnameescape(l:rcfile)
 
         " add 'sandbox' if requested
         if (s:localvimrc_sandbox != 0)


### PR DESCRIPTION
This has been added in b5973fef5676a6a11c882e2901dd3552a4ae7948, but it
prevents you from using `echom` etc.  While this could be worked around
by using `unsilent` explicitly, it seems to be a bad practice to be
silent by default.

You can always use `silent` explicitly in your `.lvimrc` file.