### PR TITLE
Fix blacklist documentation for list of patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Example:
 let g:localvimrc_blacklist='/share/projects/.*'
 
 " blacklist can also use lists of patterns
-let g:localvimrc_whitelist=['/share/projects/.*', '/usr/share/other-projects/.*']
+let g:localvimrc_blacklist=['/share/projects/.*', '/usr/share/other-projects/.*']
 ```
 
   - Default: No blacklist


### PR DESCRIPTION
This is actually pretty funny because I opened https://github.com/embear/vim-localvimrc/pull/44 in June.