### PR TITLE
Trigger a custom autocmd after sourcing

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -474,6 +474,7 @@ function! s:LocalVimRC()
           " execute the command
           exec l:command
           call s:LocalVimRCDebug(1, "sourced " . l:rcfile)
+          silent doautocmd User LocalVimRCSourced
         endif
 
         " remove global variables again


### PR DESCRIPTION
This can be used to automatically perform commands that might be needed to properly apply loaded settings, but that are not/should not be part of the local vimrc.

Example for my own setup: I use .lvimrc to set the indent style for a project. However, these changes are not automatically picked up by some of the installed plugins (example: https://github.com/nathanaelkane/vim-indent-guides), so I need to perform a command to update these. I could (and I do currently) include this command in the .lvimrc, but I feel like this doesn't really belong these, as it is in no way specific to that project. If I can instead do this as an autocommand I can avoid having to include this in every .lvimrc, limiting the contents of those to stuff that is actually specific to that project. As a bonus, it would also allow me to use sandbox mode again for most of my .lvimrc files.