### PR TITLE
Add Makefile to generate doc/localvimrc.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+doc/localvimrc.txt: README.md
+	html2vimdoc -f localvimrc README.md >$@


### PR DESCRIPTION
This could be enhanced to create a virtualenv for vim-tools in case
html2vimdoc is not installed.