### PR TITLE
Fix printf usage

### DIFF
--- a/plugin/localvimrc.vim
+++ b/plugin/localvimrc.vim
@@ -497,7 +497,7 @@ function! s:LocalVimRC()
             " execute the command
             call s:LocalVimRCSourceScript(l:rcfile, 1)
           catch /^sandbox$/
-            let l:message = printf("localvimrc: unable to use sandbox for \"" . l:rcfile . "\".")
+            let l:message = printf("localvimrc: unable to use sandbox for \"%s\".", l:rcfile)
             call s:LocalVimRCDebug(1, l:message)
 
             if (s:localvimrc_ask == 1)


### PR DESCRIPTION
Messages initially without this:

```
Messages maintainer: Bram Moolenaar <Bram@vim.org>
Error detected while processing function <SNR>70_LocalVimRC:
line  266:
E119: Not enough arguments for function: printf
E15: Invalid expression: printf("localvimrc: unable to use sandbox for \"" . l:rcfile . "\".")
```

```
VIM - Vi IMproved 8.0 (2016 Sep 12, compiled Mar 18 2020 18:29:15)
Included patches: 1-1453
```